### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that enables creation and management of Framer plugins with web3 capabilities. This server provides tools for creating, building, and managing Framer plugins with integrated web3 features like wallet connections, contract interactions, and NFT displays.
 
+<a href="https://glama.ai/mcp/servers/pd3bkgs4z4">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/pd3bkgs4z4/badge" alt="Framer Plugin Server MCP server" />
+</a>
+
 ## Features
 
 - Create new Framer plugins with web3 capabilities


### PR DESCRIPTION
This PR adds a badge for the [Framer Plugin MCP Server](https://glama.ai/mcp/servers/pd3bkgs4z4) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/pd3bkgs4z4">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/pd3bkgs4z4/badge" alt="Framer Plugin Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.